### PR TITLE
Incompatibility with Chrome version 92.0 on linux

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "name": "Crytoblades Combat Calculator",
     "action": {},
-    "manifest_version": 2,
-    "version": "0.1.1",
+    "manifest_version": 3,
+    "version": "0.1.2",
     "description": "Combat Calculator for Cryptoblades",
     "permissions": [
       "activeTab",


### PR DESCRIPTION
'action' requires manifest version of at least 3.
'scripting' requires manifest version of at least 3.
Service worker registration failed

These errors are fixed by changing to version 3